### PR TITLE
Mangle runtime.call strings in integration test output

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -142,6 +142,10 @@ func cleanOutput(o []byte, testPkg string) []byte {
 	timingRe4 := regexp.MustCompile(`SlowTest \([0-9.]+ms\)`)
 	o = timingRe4.ReplaceAll(o, []byte("SlowTest (1234ms)"))
 
+	// Replace arch-dependent runtime.call32 etc. with runtime.callXX
+	callRe := regexp.MustCompile(`runtime.call\d+`)
+	o = callRe.ReplaceAll(o, []byte("runtime.callXX"))
+
 	return o
 }
 

--- a/test_cases/golden.panicking_test
+++ b/test_cases/golden.panicking_test
@@ -6,7 +6,7 @@ panic: Panic in ExplicitPanic
 
 github.com/jacobsa/ogletest/somepkg_test.(*PanickingTest).ExplicitPanic
 	some_file.txt:0
-runtime.call32
+runtime.callXX
 	some_file.txt:0
 reflect.Value.call
 	some_file.txt:0
@@ -24,7 +24,7 @@ github.com/jacobsa/ogletest/somepkg_test.someFuncThatPanics
 	some_file.txt:0
 github.com/jacobsa/ogletest/somepkg_test.(*PanickingTest).ExplicitPanicInHelperFunction
 	some_file.txt:0
-runtime.call32
+runtime.callXX
 	some_file.txt:0
 reflect.Value.call
 	some_file.txt:0
@@ -40,7 +40,7 @@ panic: runtime error: invalid memory address or nil pointer dereference
 
 github.com/jacobsa/ogletest/somepkg_test.(*PanickingTest).NilPointerDerefence
 	some_file.txt:0
-runtime.call32
+runtime.callXX
 	some_file.txt:0
 reflect.Value.call
 	some_file.txt:0


### PR DESCRIPTION
The panicking test's golden file contains a number of runtime.call32 strings, which are really version- and architecture-dependent. As outlined in Debian bug #860646[1], go 1.7.4 on i386 will use runtime.call16 instead of runtime.call32, as would go 1.4 on amd64. `runtime.callXX` methods are really Go internal implementation details[2][3] and should be treated as such.

To ensure the integration tests run reliably in a cross-architecture manner, we extend `cleanOutput()` to mangle all instances of `runtime.call\d+` to `runtime.callXX` and update panicking's golden file accordingly.

[1] https://bugs.debian.org/860646
[2] https://github.com/golang/go/blob/go1.8.1/src/runtime/asm_386.s#L450
[3] https://github.com/golang/go/blob/go1.8.1/src/runtime/asm_amd64.s#L446