### PR TITLE
Fix build failure with golang 1.11 (Update golden files)

### DIFF
--- a/test_cases/golden.panicking_test
+++ b/test_cases/golden.panicking_test
@@ -20,7 +20,7 @@ TearDown running.
 panicking_test.go:34:
 panic: Panic in someFuncThatPanics
 
-github.com/jacobsa/ogletest/somepkg_test.someFuncThatPanics
+github.com/jacobsa/ogletest/somepkg_test.(*PanickingTest).ExplicitPanicInHelperFunction
 	some_file.txt:0
 github.com/jacobsa/ogletest/somepkg_test.(*PanickingTest).ExplicitPanicInHelperFunction
 	some_file.txt:0


### PR DESCRIPTION
The output of golang 1.11 has changed -- this makes the test pass again.